### PR TITLE
use provision-with-micromamba action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
-          mamba-version: '*'
-          channels: conda-forge
-          activate-environment: datasetsforecast
-          environment-file: environment.yml
+          extra-specs: python=${{ matrix.python-version }}
+          cache-env: true
 
       - name: Install pip requirements
         run: pip install ./

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,8 @@ dependencies:
   - numpy
   - pandas
   - pip
+  - requests
+  - tqdm
+  - xlrd>=1.0.0
   - pip:
     - nbdev
-    - tqdm
-    - xlrd>=1.0.0

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = False
 license = mit
 status = 2
-requirements = numpy pandas tqdm xlrd>=1.0.0
+requirements = numpy pandas requests tqdm xlrd>=1.0.0
 nbs_path = nbs
 doc_path = _docs
 recursive = False


### PR DESCRIPTION
Uses micromamba instead of miniconda for the environment setup. The advantage is that micromamba's setup is insanely fast and caches whole environments, so subsequent runs of the same PR can reuse the cache from previous runs or from the main branch. The cache expires after a day.