### PR TITLE
[FEAT] Add hierarchical data tests

### DIFF
--- a/nbs/hierarchical.ipynb
+++ b/nbs/hierarchical.ipynb
@@ -259,6 +259,16 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "from fastcore.test import test_close"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
     "for group, _ in HierarchicalInfo:\n",
     "    Y_df, S, tags = HierarchicalData.load('./data', group)\n",
     "    assert all(S.loc[cats].values.sum() == S.shape[1] for _, cats in tags.items())\n",
@@ -267,7 +277,16 @@
     "    S_hiers = np.vstack(S_hiers)\n",
     "    S_hiers = S_hiers.sum(axis=0)\n",
     "    is_strictly_hierarchical = np.array_equal(S_hiers, np.sort(S_hiers))\n",
-    "    print(f'Is {group} strictly hierarchical? {is_strictly_hierarchical}')"
+    "    print(f'Is {group} strictly hierarchical? {is_strictly_hierarchical}')\n",
+    "    \n",
+    "    # test S recovers Y_df\n",
+    "    for key, hiers in tags.items():\n",
+    "        for ts, bottom_ts in S.loc[hiers].iterrows():\n",
+    "            actual_bottom_ts = bottom_ts.loc[lambda x: x == 1].index\n",
+    "            test_close(\n",
+    "                Y_df.query('unique_id == @ts')['y'].sum(), \n",
+    "                Y_df.query('unique_id in @actual_bottom_ts')['y'].sum()\n",
+    "            )"
    ]
   },
   {


### PR DESCRIPTION
This PR ensures that the summing matrix outputed by `HierarchicalData` actually recovers `Y_df`.﻿
