### PR TITLE
skip tests when only docs are changed

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,8 +3,12 @@ name: pytest
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
In this PR, we skip running all pytest tests when we are only updating the docs. This saves a lot of time, enabling quicker builds