### PR TITLE
docs: fix typos and copy-paste errors in m4/m5/phm2008 docs

### DIFF
--- a/datasetsforecast/m4.py
+++ b/datasetsforecast/m4.py
@@ -231,7 +231,7 @@ class M4Evaluation:
     @staticmethod
     def load_benchmark(directory: str, group: str,
                        source_url: Optional[str] = None) -> np.ndarray:
-        """Downloads and loads a bechmark forecasts.
+        """Downloads and loads benchmark forecasts.
 
         Args:
             directory (str): Directory where data will be downloaded.

--- a/datasetsforecast/m5.py
+++ b/datasetsforecast/m5.py
@@ -159,14 +159,14 @@ class M5Evaluation:
     def load_benchmark(directory: str,
                        source_url: Optional[str] = None,
                        validation: bool = False) -> np.ndarray:
-        """Downloads and loads a bechmark forecasts.
+        """Downloads and loads benchmark forecasts.
 
         Args:
             directory (str): Directory where data will be downloaded.
             source_url (str, optional): Optional benchmark url obtained from
                 https://github.com/Nixtla/m5-forecasts/tree/master/forecasts.
                 If `None` returns the M5 winner.
-            validation (bool): Wheter return validation forecasts.
+            validation (bool): Whether return validation forecasts.
                 Default False, return test forecasts.
 
         Returns:
@@ -211,7 +211,7 @@ class M5Evaluation:
     def aggregate_levels(y_hat: pd.DataFrame,
                          categories: pd.DataFrame = None) -> pd.DataFrame:
         """
-        Aggregates the 30_480 series to get 42_840.
+        Aggregates the 30_490 series to get 42_840.
 
         Args:
             y_hat (pd.DataFrame): Forecasts as wide pandas dataframe with columns ['unique_id'].
@@ -241,11 +241,11 @@ class M5Evaluation:
     def evaluate(directory: str,
                  y_hat: Union[pd.DataFrame, str],
                  validation: bool = False) -> pd.DataFrame:
-        """Evaluates y_hat according to M4 methodology.
+        """Evaluates y_hat according to M5 methodology.
 
         Args:
             directory (str): Directory where data will be downloaded.
-            validation (bool): Wheter perform validation evaluation.
+            validation (bool): Whether perform validation evaluation.
                 Default False, return test evaluation.
             y_hat (Union[pd.DataFrame, str]): Forecasts as wide pandas dataframe with columns
                 ['unique_id'] and forecasts or
@@ -253,8 +253,8 @@ class M5Evaluation:
                 https://github.com/Nixtla/m5-forecasts/tree/main/forecasts.
 
         Returns:
-            pd.DataFrame: DataFrame with columns OWA, SMAPE, MASE
-                and group as index.
+            pd.DataFrame: DataFrame with column wrmsse and Level_id
+                (plus a 'Total' row) as index.
 
         Examples:
 

--- a/datasetsforecast/phm2008.py
+++ b/datasetsforecast/phm2008.py
@@ -62,7 +62,6 @@ PHM2008Info = Info((FD001, FD002, FD003, FD004))
 @dataclass
 class PHM2008:
 
-    #source_url = 'https://forecasters.org/data/m3comp/M3C.xls'
     source_url = 'https://www.dropbox.com/s/1od45uh37tplxt7/CMAPSSData.zip?dl=1'
 
     @staticmethod
@@ -82,7 +81,7 @@ class PHM2008:
     @staticmethod
     def load(directory: str, group: str, clip_rul: bool=True) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
-        Downloads and loads M3 data.
+        Downloads and loads PHM2008 data.
 
         Args:
             directory (str): Directory where data will be downloaded.

--- a/docs/favorita.html.md
+++ b/docs/favorita.html.md
@@ -36,6 +36,28 @@ hplots.plot_hierarchically_linked_series(
 
 ::: datasetsforecast.favorita.load_preprocessed
 
+## Kaggle-Competition References
+
+The evaluation metric of the Favorita Kaggle competition was the
+normalized weighted root mean squared logarithmic error (NWRMSLE).
+Perishable items have a score weight of 1.25; otherwise, the weight is
+1.0.
+
+$$ NWRMSLE = \sqrt{\frac{\sum^{n}_{i=1} w_{i}\left(log(\hat{y}_{i}+1)  - log(y_{i}+1)\right)^{2}}{\sum^{n}_{i=1} w_{i}}}$$
+
+| Kaggle Competition Forecasting Methods | 16D ahead NWRMSLE |
+|:---------------------------------------------------------------:|:-----:|
+| [LGBM](https://www.kaggle.com/shixw125/1st-place-lgb-model-public-0-506-private-0-511/comments) \[1\] | 0.5091 |
+| [Seq2Seq WaveNet](https://arxiv.org/abs/1803.04037) \[2\] | 0.5129 |
+
+1. [Corporación Favorita. Corporación favorita grocery sales
+    forecasting. Kaggle Competition Leaderboard,
+    2018.](https://www.kaggle.com/c/favorita-grocery-sales-forecasting/leaderboard)
+2. [Glib Kechyn, Lucius Yu, Yangguang Zang, and Svyatoslav Kechyn.
+    Sales forecasting using wavenet within the framework of the Favorita
+    Kaggle competition. Computing Research Repository, abs/1803.04037,
+    2018](https://arxiv.org/abs/1803.04037).
+
 ## Auxiliary Functions
 
 This auxiliary functions are used to efficiently create and wrangle

--- a/docs/m4.html.md
+++ b/docs/m4.html.md
@@ -59,7 +59,7 @@ description: M4 dataset
 The method `evaluate` from the class
 [`M4Evaluation`](https://Nixtla.github.io/datasetsforecast/m4.html#m4evaluation)
 can receive a url of a [benchmark uploaded to the M4
-competiton](https://github.com/Mcompetitions/M4-methods/tree/master/Point%20Forecasts).
+competition](https://github.com/Mcompetitions/M4-methods/tree/master/Point%20Forecasts).
 
 The results compared to the on-the-fly evaluation were obtained from the
 [official
@@ -79,7 +79,7 @@ esrnn_evaluation
 
 ### Numpy-based evaluation
 
-Also the method `evaluate` can recevie a numpy array of forecasts.
+Also the method `evaluate` can receive a numpy array of forecasts.
 
 ```python
 import numpy as np

--- a/docs/m5.html.md
+++ b/docs/m5.html.md
@@ -16,7 +16,7 @@ description: M5 dataset
 The method `evaluate` from the class
 [`M5Evaluation`](https://Nixtla.github.io/datasetsforecast/m5.html#m5evaluation)
 can receive a url of a [submission to the M5
-competiton](https://github.com/Nixtla/m5-forecasts/tree/main/forecasts).
+competition](https://github.com/Nixtla/m5-forecasts/tree/main/forecasts).
 
 The results compared to the on-the-fly evaluation were obtained from the
 [official
@@ -32,7 +32,7 @@ winner_evaluation
 
 ### Pandas-based evaluation
 
-Also the method `evaluate` can recevie a pandas DataFrame of forecasts.
+Also the method `evaluate` can receive a pandas DataFrame of forecasts.
 
 ```python
 m5_second_place_url = 'https://github.com/Nixtla/m5-forecasts/raw/main/forecasts/0002 Matthias.zip'
@@ -62,25 +62,3 @@ winner_benchmark_val = M5Evaluation.load_benchmark('data', validation=True)
 winner_evaluation_val = M5Evaluation.evaluate('data', winner_benchmark_val, validation=True)
 winner_evaluation_val
 ```
-
-## Kaggle-Competition-M5 References
-
-The evaluation metric of the Favorita Kaggle competition was the
-normalized weighted root mean squared logarithmic error (NWRMSLE).
-Perishable items have a score weight of 1.25; otherwise, the weight is
-1.0.
-
-$$ NWRMSLE = \sqrt{\frac{\sum^{n}_{i=1} w_{i}\left(log(\hat{y}_{i}+1)  - log(y_{i}+1)\right)^{2}}{\sum^{n}_{i=1} w_{i}}}$$
-
-| Kaggle Competition Forecasting Methods | 16D ahead NWRMSLE |
-|:---------------------------------------------------------------:|:-----:|
-| [LGBM](https://www.kaggle.com/shixw125/1st-place-lgb-model-public-0-506-private-0-511/comments) \[1\] | 0.5091 |
-| [Seq2Seq WaveNet](https://arxiv.org/abs/1803.04037) \[2\] | 0.5129 |
-
-1. [Corporación Favorita. Corporación favorita grocery sales
-    forecasting. Kaggle Competition Leaderboard,
-    2018.](https://www.kaggle.com/c/favorita-grocery-sales-forecasting/leaderboard)
-2. [Glib Kechyn, Lucius Yu, Yangguang Zang, and Svyatoslav Kechyn.
-    Sales forecasting using wavenet within the framework of the Favorita
-    Kaggle competition. Computing Research Repository, abs/1803.04037,
-    2018](https://arxiv.org/abs/1803.04037).


### PR DESCRIPTION
## What

Fixes documentation typos and factual copy-paste errors in the M4, M5, and PHM2008 dataset/evaluation classes, found during the 2026-07-19 Nixtla site QA review.

## Why

Several docstrings and doc pages had been copy-pasted between the M3/M4/M5/PHM2008 modules without updating the dataset-specific details, leaving factually wrong descriptions of what each method does.

## How

- Spelling: `bechmark`→`benchmark`, `competiton`→`competition`, `recevie`→`receive`, `Wheter`→`Whether`.
- `PHM2008.load()`'s docstring said "Downloads and loads M3 data." (copied from the M3 loader) — now says PHM2008 data, matching what the method actually downloads/loads.
- `M5Evaluation.evaluate()`'s docstring said "according to M4 methodology" and its `Returns` block described M4's `OWA`/`SMAPE`/`MASE` columns — now correctly describes M5's WRMSSE methodology and its actual return shape (single `wrmsse` column indexed by `Level_id`, verified by reading the method body).
- `docs/m5.html.md` had an entire "Kaggle-Competition-M5 References" section that was actually about the Favorita Kaggle competition (NWRMSLE metric, Favorita leaderboard entries and citations) — removed, since fabricating new M5/WRMSSE benchmark citations to replace it isn't something I can do responsibly without a verified source.
- Removed a stale commented-out M3 dataset URL in `phm2008.py`, a leftover from the same copy-paste origin.
- Corrected the M5 bottom-level series count (30,480 → 30,490 — 3,049 products × 10 stores, per the M5 competition's own published dataset description).

Leaves `datasetsforecast/long_horizon2.py` untouched — its `arxiv.org` link typo is already covered by #106.

## Testing

- [x] `python3 -m py_compile` on all 3 changed `.py` files (no new warnings/errors beyond pre-existing unrelated `\s` regex warnings in `phm2008.py`).
- [x] Verified both docstring corrections against the actual method bodies (traced `PHM2008.load()`'s download URL and file reads; traced `M5Evaluation.evaluate()`'s full computation to confirm it returns a `wrmsse`-only frame, not `OWA`/`SMAPE`/`MASE`).
- [x] Confirmed no other stray instances of the fixed typos remain anywhere in the repo.

## Checklist

- [x] Title follows conventional commits format
- [x] PR is focused on a single concern (documentation accuracy)
- [x] Self-reviewed the diff before requesting review
- [x] No secrets, credentials, or PII in the diff